### PR TITLE
feat: add configurable docker repository

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,7 @@ builds:
       - arm64
 dockers:
   - image_templates:
-    - "mesosphere/{{.ProjectName}}:{{ .Tag }}-amd64"
+    - "{{.Env.DOCKER_REPOSITORY}}/{{.ProjectName}}:{{ .Tag }}-amd64"
     dockerfile: Dockerfile
     use_buildx: true
     build_flag_templates:
@@ -42,7 +42,7 @@ dockers:
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/amd64"
   - image_templates:
-    - "mesosphere/{{.ProjectName}}:{{ .Tag }}-arm64"
+    - "{{.Env.DOCKER_REPOSITORY}}/{{.ProjectName}}:{{ .Tag }}-arm64"
     dockerfile: Dockerfile
     use_buildx: true
     build_flag_templates:
@@ -55,10 +55,10 @@ dockers:
       - "--platform=linux/arm64"
     goarch: arm64
 docker_manifests:
-  - name_template: "mesosphere/{{.ProjectName}}:{{ .Tag }}"
+  - name_template: "{{.Env.DOCKER_REPOSITORY}}/{{.ProjectName}}:{{ .Tag }}"
     image_templates:
-      - "mesosphere/{{.ProjectName}}:{{ .Tag }}-amd64"
-      - "mesosphere/{{.ProjectName}}:{{ .Tag }}-arm64"
+      - "{{.Env.DOCKER_REPOSITORY}}/{{.ProjectName}}:{{ .Tag }}-amd64"
+      - "{{.Env.DOCKER_REPOSITORY}}/{{.ProjectName}}:{{ .Tag }}-arm64"
 archives:
   - format_overrides:
     - goos: windows

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ SHELL := /bin/bash -euo pipefail
 
 INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 
+DOCKER_REPOSITORY ?= mesosphere
+
 export GOMODULENAME := $(shell go list -m)
+export DOCKER_REPOSITORY := $(DOCKER_REPOSITORY)
 
 ifneq ($(shell git status --porcelain 2>/dev/null; echo $$?), 0)
 	export GIT_TREE_STATE := dirty

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,9 @@ SHELL := /bin/bash -euo pipefail
 
 INTERACTIVE := $(shell [ -t 0 ] && echo 1)
 
-DOCKER_REPOSITORY ?= mesosphere
+export DOCKER_REPOSITORY ?= mesosphere
 
 export GOMODULENAME := $(shell go list -m)
-export DOCKER_REPOSITORY := $(DOCKER_REPOSITORY)
 
 ifneq ($(shell git status --porcelain 2>/dev/null; echo $$?), 0)
 	export GIT_TREE_STATE := dirty


### PR DESCRIPTION
This PR makes `goreleaser` docker repository target configurable with defaulting to `mesosphere`.

It allows to build project into a custom repository like:

```
make release-snapshot DOCKER_REPOSITORY=mhrabovcin
```